### PR TITLE
Fixed the missing social footer when using Dia broswer.

### DIFF
--- a/_sass/components/_footer.scss
+++ b/_sass/components/_footer.scss
@@ -41,6 +41,7 @@ html, body {
     }
 
     &-social {
+        display: block !important;
         flex: 1;
         min-width: 200px;
         h4 {


### PR DESCRIPTION
On dia browser, there is a default css applied to the page to hide the section.
<img width="610" height="56" alt="image" src="https://github.com/user-attachments/assets/c767a715-7fe0-4c42-b606-e1fea3bee04b" />

